### PR TITLE
Add about page and update landing features

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,32 @@
+import Nav from "@/components/nav";
+
+export default function About() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Nav />
+
+      <main className="flex-1 px-6">
+        <div className="max-w-3xl mx-auto py-12">
+          <h1 className="text-3xl md:text-4xl font-bold mb-6 text-center">
+            About Habee
+          </h1>
+          <p className="text-lg leading-relaxed text-balance">
+            Habee was built to make habit tracking simple and distraction-free.
+            The app focuses on a minimal interface that keeps your routines
+            front and center without ads or analytics.
+          </p>
+          <p className="mt-6 text-lg leading-relaxed text-balance">
+            Our goal is to help you stay consistent over the long term. Habee
+            lets you manage habits, schedule reminders, and control your data
+            with features like account deletion and habit archiving.
+          </p>
+        </div>
+      </main>
+
+      <footer className="py-8 text-center text-sm mt-auto">
+        © {new Date().getFullYear()} Habee. Built by Mirza Digital Group.
+      </footer>
+    </div>
+  );
+}
+

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,17 @@
+import { Card } from "@/components/Card";
+import { FeatureRow } from "@/components/FeatureRow";
 import Nav from "@/components/nav";
+import {
+  CalendarCheck,
+  Hexagon,
+  Bell,
+  Archive,
+  Edit,
+  LayoutGrid,
+  NotebookPen,
+  Moon,
+  Scaling,
+} from "lucide-react";
 
 export default function About() {
   return (
@@ -7,139 +20,173 @@ export default function About() {
 
       <main className="flex-1 px-6">
         <div className="max-w-3xl mx-auto py-12">
-          <h1 className="text-3xl md:text-4xl font-bold mb-2 text-center">
-            About Habee
-          </h1>
-          <p className="text-center text-sm opacity-70">
-            Habee (ha‑bee) — habits with intention, visuals that keep you going.
-          </p>
+          {/* Title */}
+          <header className="text-center">
+            <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight">
+              About Habee
+            </h1>
+            <div className="inline-flex items-center gap-2 mt-3">
+              <span className="text-sm opacity-70">Habee (ha‑bee)</span>
+            </div>
+          </header>
 
-          {/* Why I built Habee */}
-          <section className="mt-10 space-y-6">
-            <h2 className="text-xl font-semibold">Why I built it</h2>
-            <p className="text-lg leading-relaxed text-balance">
-              I used to track habits in a spreadsheet. It worked: I’d tick off
-              my day, then get a little dopamine hit seeing a{" "}
-              <strong>colour‑coded month</strong>. That view gave me honest
-              feedback — what was working and what wasn’t — so I could{" "}
-              <strong>adjust goals to reality</strong>. If 10k steps wasn’t
-              happening for weeks, I’d shift to 8k. If “take supplements” was
-              perfect for 3 months, I’d archive it and make room for a new
-              habit.
-            </p>
-            <p className="text-lg leading-relaxed text-balance">
-              The downside? Spreadsheets are clunky on a phone — horizontal
-              scrolling, fiddly cells, slow on the move. The apps I tried were
-              either <strong>paywalled</strong> for basic usage or{" "}
-              <strong>cluttered with ads</strong>. So I built Habee with a
-              simple philosophy:{" "}
-              <strong>clean, ad‑free, distraction‑free</strong>.
-            </p>
+          {/* Why I built it */}
+          <section className="mt-12">
+            <Card>
+              <h2 className="text-xl font-semibold">Why I built it</h2>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                I used to track habits in a spreadsheet. It worked: ticking off
+                days and seeing a <strong>colour‑coded month</strong> gave
+                honest feedback. Wins were rewarding; misses told me to{" "}
+                <strong>adjust goals to reality</strong> — 10k steps → 8k, or
+                archiving “take supplements” after months of consistency.
+              </p>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                The downside? Spreadsheets are clunky on a phone — horizontal
+                scrolling, fiddly cells, slow on the move. Most apps I tried
+                were either
+                <strong> paywalled</strong> for basic use or{" "}
+                <strong>cluttered with ads</strong>. So I built Habee:{" "}
+                <strong>clean, ad‑free, distraction‑free</strong>.
+              </p>
+            </Card>
           </section>
 
           {/* Brand & philosophy */}
-          <section className="mt-12 space-y-6">
-            <h2 className="text-xl font-semibold">What Habee stands for</h2>
-            <p className="text-lg leading-relaxed text-balance">
-              <strong>Habee</strong> is <em>habit</em> + <em>bee</em>. The brand
-              is <strong>black and yellow</strong> because we take our cue from
-              the bee: consistent work, done over time, creating value and
-              beauty. You’ll see <strong>hexagons</strong> in the design — a nod
-              to the honeycomb. Simple building blocks that, when repeated,
-              become something strong.
-            </p>
-            <p className="text-lg leading-relaxed text-balance">
-              Habee isn’t trying to be an overwhelming productivity suite. It’s
-              a <strong>simple habit tracker</strong> that makes you{" "}
-              <strong>feel good about progress</strong> and gives you{" "}
-              <strong>satisfying visuals</strong> to stay consistent.
-            </p>
+          <section className="mt-10">
+            <Card accent>
+              <h2 className="text-xl font-semibold">What Habee stands for</h2>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                <strong>Habee</strong> blends <em>habit</em> + <em>bee</em>. The{" "}
+                <strong>black &amp; yellow</strong> identity nods to focused,
+                consistent work. You’ll notice <strong>hexagons</strong>{" "}
+                throughout — a honeycomb motif: simple building blocks that
+                compound into something strong.
+              </p>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                Not a bloated “productivity suite” — just a{" "}
+                <strong>simple habit tracker</strong> that makes you{" "}
+                <strong>feel good about progress</strong> with
+                <strong> satisfying visuals</strong>.
+              </p>
+            </Card>
           </section>
 
-          {/* How it works / Ideal workflow */}
-          <section className="mt-12 space-y-6">
-            <h2 className="text-xl font-semibold">How it’s meant to be used</h2>
-            <p className="text-lg leading-relaxed text-balance">
-              The ideal workflow is deliberately short:
-            </p>
-            <ol className="list-decimal pl-6 text-lg leading-relaxed space-y-2">
-              <li>Open the app once a day.</li>
-              <li>Tick off what you did (leave missed items blank).</li>
-              <li>Close the app — total time: ~20 seconds.</li>
-            </ol>
-            <p className="text-lg leading-relaxed text-balance">
-              Habee handles the visuals — no formatting, no spreadsheet setup —
-              just an automatically generated <strong>calendar view</strong>{" "}
-              that reflects your month at a glance.
-            </p>
+          {/* How to use */}
+          <section className="mt-10">
+            <Card>
+              <h2 className="text-xl font-semibold">
+                How it’s meant to be used
+              </h2>
+              <p className="mt-4 text-lg leading-relaxed">
+                Keep it light and repeatable:
+              </p>
+              <ol className="list-decimal pl-6 mt-2 text-lg leading-relaxed space-y-2">
+                <li>Open the app once a day.</li>
+                <li>Tick off what you did (leave misses blank).</li>
+                <li>Close the app — ~20 seconds total.</li>
+              </ol>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                Habee handles the visuals for you — an automatic
+                <strong> calendar view</strong> that reflects your month at a
+                glance.
+              </p>
+            </Card>
           </section>
 
           {/* Current features */}
-          <section className="mt-12 space-y-4">
-            <h2 className="text-lg font-semibold mt-6">
-              What’s in the app today
-            </h2>
-            <ul className="list-disc pl-6 text-lg leading-relaxed space-y-2">
-              <li>Clean daily logging with a focused UI.</li>
-              <li>
-                Option to also create weekly habits. Some tasks might not be
-                daily - like journalling or cleaning your room, so the option to
-                create habits that are only valid on the days of the week of
-                your choosing. For example, a habit set only for Sunday will not
-                show up on the other days of the week. On the calendar screen,
-                it will not affect the visuals of days it is not registered for
-                and on the grid screen will appear as grey instead of red (which
-                usually indicates a missed habit)
-              </li>
-              <li>
-                Colour‑coded calendar to see streaks and trends. Users can also
-                press on the calendar cells to get more information about days
-                of the week - like how many habits were completed for that
-                specific day.
-              </li>
-              <li>
-                Optional reminders that nudge, not nag. Users can set up a daily
-                reminder in the notifications setting to remind them to log
-                habits. Additionally, custom reminders can be set per habit
-                using the edit habit menu on the home screen.{" "}
-              </li>
-              <li>
-                Manage habits over time with archiving. Some habits might be
-                seasonal or considered complete. If so, the continuing to track
-                them may not be productive, but instead of continuing to tick
-                them off over time or ignoring them to show up as red, users can
-                archive the habits to retire anything they are done with without
-                deleting all the visual progress it built up.
-              </li>
-              <li>
-                Habit names can also be edited for any spelling mistakes or
-                changes, as well as the option to fully delete the habit to
-                remove it from all visual progress tracking.
-              </li>
-            </ul>
-
-            <h2 className="text-lg font-semibold mt-6">Future of Habee?</h2>
-            <p className="text-lg leading-relaxed text-balance">
-              The plan for Habee is to continously improve based on user
-              feedback, and build something that truly reflects the desires of
-              the community. Please leave feedback via the App Store or at
-              habee.app@gmail.com Some of the current features in the pipeline
-              include: dark mode, journalling and non-binary habit logging. With
-              this, users will be able to track things like daily calories and
-              have the app calculate weekly averages to make goals like being in
-              a deficit easier (instead of daily calorie tracking where Weekends
-              make it tough to maintain a daily deficit)
-            </p>
+          <section className="mt-12">
+            <h2 className="text-xl font-semibold">What’s in the app today</h2>
+            <div className="mt-6 grid gap-4">
+              <FeatureRow
+                icon={<CalendarCheck className="w-5 h-5" aria-hidden />}
+                title="Clean daily logging"
+                desc="Fast, focused check‑ins with a minimal UI."
+              />
+              <FeatureRow
+                icon={<Hexagon className="w-5 h-5" aria-hidden />}
+                title="Weekly habits (by day)"
+                desc="Schedule habits for specific weekdays. Unscheduled days don’t penalise your visuals; in the grid they appear grey (not red)."
+              />
+              <FeatureRow
+                icon={<LayoutGrid className="w-5 h-5" aria-hidden />}
+                title="Colour‑coded calendar"
+                desc="See streaks and trends; tap a day for completions and details."
+              />
+              <FeatureRow
+                icon={<Bell className="w-5 h-5" aria-hidden />}
+                title="Smart reminders"
+                desc="Set a daily reminder or per‑habit custom nudges — supportive, not spammy."
+              />
+              <FeatureRow
+                icon={<Archive className="w-5 h-5" aria-hidden />}
+                title="Archive & evolve"
+                desc="Retire seasonal or ‘complete’ habits without losing past progress."
+              />
+              <FeatureRow
+                icon={<Edit className="w-5 h-5" aria-hidden />}
+                title="Edit or delete"
+                desc="Fix names, fine‑tune scope, or remove a habit entirely."
+              />
+            </div>
           </section>
 
-          {/* CTAs */}
-          <section className="mt-12 flex flex-col sm:flex-row gap-4">
-            <a
-              href="/support"
-              className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold text-center"
-            >
-              How to support Habee
-            </a>
+          {/* Roadmap */}
+          <section className="mt-12">
+            <Card>
+              <h2 className="text-xl font-semibold">Where it’s going</h2>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                Incremental improvements guided by user feedback — without
+                bloat. On the near‑term list:
+              </p>
+              <ul className="mt-4 list-disc pl-6 text-lg leading-relaxed space-y-2">
+                <li className="flex items-start gap-2">
+                  <Moon className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <span>
+                    <strong>Dark mode</strong> — easier on the eyes, same clean
+                    UI.
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <NotebookPen className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <span>
+                    <strong>Journalling</strong> — optional reflections
+                    alongside your habits.
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <Scaling className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <span>
+                    <strong>Non‑binary logging</strong> — track ranges/values
+                    (e.g., calories) and see weekly averages to support flexible
+                    goals.
+                  </span>
+                </li>
+              </ul>
+
+              <p className="mt-6 text-lg leading-relaxed">
+                Have ideas? Email{" "}
+                <a
+                  className="underline decoration-[var(--accent)] underline-offset-4"
+                  href="mailto:habee.app@gmail.com"
+                >
+                  habee.app@gmail.com
+                </a>{" "}
+                or leave a review on the App Store.
+              </p>
+            </Card>
+          </section>
+
+          {/* CTA */}
+          <section className="mt-12">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a
+                href="/support"
+                className="bg-[var(--accent)]  text-black px-6 py-3 rounded-full font-semibold text-center hover:opacity-90 transition"
+              >
+                How to support Habee
+              </a>
+            </div>
           </section>
         </div>
       </main>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,19 +7,140 @@ export default function About() {
 
       <main className="flex-1 px-6">
         <div className="max-w-3xl mx-auto py-12">
-          <h1 className="text-3xl md:text-4xl font-bold mb-6 text-center">
+          <h1 className="text-3xl md:text-4xl font-bold mb-2 text-center">
             About Habee
           </h1>
-          <p className="text-lg leading-relaxed text-balance">
-            Habee was built to make habit tracking simple and distraction-free.
-            The app focuses on a minimal interface that keeps your routines
-            front and center without ads or analytics.
+          <p className="text-center text-sm opacity-70">
+            Habee (ha‑bee) — habits with intention, visuals that keep you going.
           </p>
-          <p className="mt-6 text-lg leading-relaxed text-balance">
-            Our goal is to help you stay consistent over the long term. Habee
-            lets you manage habits, schedule reminders, and control your data
-            with features like account deletion and habit archiving.
-          </p>
+
+          {/* Why I built Habee */}
+          <section className="mt-10 space-y-6">
+            <h2 className="text-xl font-semibold">Why I built it</h2>
+            <p className="text-lg leading-relaxed text-balance">
+              I used to track habits in a spreadsheet. It worked: I’d tick off
+              my day, then get a little dopamine hit seeing a{" "}
+              <strong>colour‑coded month</strong>. That view gave me honest
+              feedback — what was working and what wasn’t — so I could{" "}
+              <strong>adjust goals to reality</strong>. If 10k steps wasn’t
+              happening for weeks, I’d shift to 8k. If “take supplements” was
+              perfect for 3 months, I’d archive it and make room for a new
+              habit.
+            </p>
+            <p className="text-lg leading-relaxed text-balance">
+              The downside? Spreadsheets are clunky on a phone — horizontal
+              scrolling, fiddly cells, slow on the move. The apps I tried were
+              either <strong>paywalled</strong> for basic usage or{" "}
+              <strong>cluttered with ads</strong>. So I built Habee with a
+              simple philosophy:{" "}
+              <strong>clean, ad‑free, distraction‑free</strong>.
+            </p>
+          </section>
+
+          {/* Brand & philosophy */}
+          <section className="mt-12 space-y-6">
+            <h2 className="text-xl font-semibold">What Habee stands for</h2>
+            <p className="text-lg leading-relaxed text-balance">
+              <strong>Habee</strong> is <em>habit</em> + <em>bee</em>. The brand
+              is <strong>black and yellow</strong> because we take our cue from
+              the bee: consistent work, done over time, creating value and
+              beauty. You’ll see <strong>hexagons</strong> in the design — a nod
+              to the honeycomb. Simple building blocks that, when repeated,
+              become something strong.
+            </p>
+            <p className="text-lg leading-relaxed text-balance">
+              Habee isn’t trying to be an overwhelming productivity suite. It’s
+              a <strong>simple habit tracker</strong> that makes you{" "}
+              <strong>feel good about progress</strong> and gives you{" "}
+              <strong>satisfying visuals</strong> to stay consistent.
+            </p>
+          </section>
+
+          {/* How it works / Ideal workflow */}
+          <section className="mt-12 space-y-6">
+            <h2 className="text-xl font-semibold">How it’s meant to be used</h2>
+            <p className="text-lg leading-relaxed text-balance">
+              The ideal workflow is deliberately short:
+            </p>
+            <ol className="list-decimal pl-6 text-lg leading-relaxed space-y-2">
+              <li>Open the app once a day.</li>
+              <li>Tick off what you did (leave missed items blank).</li>
+              <li>Close the app — total time: ~20 seconds.</li>
+            </ol>
+            <p className="text-lg leading-relaxed text-balance">
+              Habee handles the visuals — no formatting, no spreadsheet setup —
+              just an automatically generated <strong>calendar view</strong>{" "}
+              that reflects your month at a glance.
+            </p>
+          </section>
+
+          {/* Current features */}
+          <section className="mt-12 space-y-4">
+            <h2 className="text-lg font-semibold mt-6">
+              What’s in the app today
+            </h2>
+            <ul className="list-disc pl-6 text-lg leading-relaxed space-y-2">
+              <li>Clean daily logging with a focused UI.</li>
+              <li>
+                Option to also create weekly habits. Some tasks might not be
+                daily - like journalling or cleaning your room, so the option to
+                create habits that are only valid on the days of the week of
+                your choosing. For example, a habit set only for Sunday will not
+                show up on the other days of the week. On the calendar screen,
+                it will not affect the visuals of days it is not registered for
+                and on the grid screen will appear as grey instead of red (which
+                usually indicates a missed habit)
+              </li>
+              <li>
+                Colour‑coded calendar to see streaks and trends. Users can also
+                press on the calendar cells to get more information about days
+                of the week - like how many habits were completed for that
+                specific day.
+              </li>
+              <li>
+                Optional reminders that nudge, not nag. Users can set up a daily
+                reminder in the notifications setting to remind them to log
+                habits. Additionally, custom reminders can be set per habit
+                using the edit habit menu on the home screen.{" "}
+              </li>
+              <li>
+                Manage habits over time with archiving. Some habits might be
+                seasonal or considered complete. If so, the continuing to track
+                them may not be productive, but instead of continuing to tick
+                them off over time or ignoring them to show up as red, users can
+                archive the habits to retire anything they are done with without
+                deleting all the visual progress it built up.
+              </li>
+              <li>
+                Habit names can also be edited for any spelling mistakes or
+                changes, as well as the option to fully delete the habit to
+                remove it from all visual progress tracking.
+              </li>
+            </ul>
+
+            <h2 className="text-lg font-semibold mt-6">Future of Habee?</h2>
+            <p className="text-lg leading-relaxed text-balance">
+              The plan for Habee is to continously improve based on user
+              feedback, and build something that truly reflects the desires of
+              the community. Please leave feedback via the App Store or at
+              habee.app@gmail.com Some of the current features in the pipeline
+              include: dark mode, journalling and non-binary habit logging. With
+              this, users will be able to track things like daily calories and
+              have the app calculate weekly averages to make goals like being in
+              a deficit easier (instead of daily calorie tracking where Weekends
+              make it tough to maintain a daily deficit)
+            </p>
+          </section>
+
+          {/* CTAs */}
+          <section className="mt-12 flex flex-col sm:flex-row gap-4">
+            <a
+              href="/support"
+              className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold text-center"
+            >
+              How to support Habee
+            </a>
+          </section>
         </div>
       </main>
 
@@ -29,4 +150,3 @@ export default function About() {
     </div>
   );
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,10 @@
-import { CalendarCheck, BarChart, Bell } from "lucide-react";
 import Link from "next/link";
+import Nav from "@/components/nav";
 
 export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">
-      <header className="bg-[var(--accent)] py-4 px-6">
-        <div className="mx-auto flex items-center justify-between">
-          <Link
-            href="/"
-            className="text-2xl font-bold text-black hover:text-white transition-colors"
-          >
-            habee
-          </Link>
-          <nav className="flex gap-6 text-sm font-medium text-black">
-            <a href="#donate" className="hover:text-white">
-              Support
-            </a>
-            <Link href="/privacy" className="hover:text-white">
-              Privacy
-            </Link>
-          </nav>
-        </div>
-      </header>
+      <Nav />
 
       <main className="flex-1 flex flex-col items-center text-center px-6">
         <div className="max-w-3xl w-full">
@@ -35,63 +18,42 @@ export default function Home() {
             satisfying visual of your long-term progress.
           </p>
           <div className="mt-10 flex flex-col sm:flex-row justify-center gap-4">
-            <a
-              href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/support"
               className="bg-[var(--accent)] text-black px-6 py-3 rounded-full font-semibold"
             >
               Support
-            </a>
-            <a
-              href="https://github.com/shafiul23/habee-app"
-              target="_blank"
-              rel="noopener noreferrer"
+            </Link>
+            <Link
+              href="/about"
               className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold"
             >
-              View GitHub
-            </a>
+              About
+            </Link>
           </div>
         </div>
       </main>
 
       <section id="features" className="py-16 px-6 bg-[var(--accent)] mt-10">
-        <div className="max-w-6xl mx-auto text-center">
-          <h2 className="text-3xl md:text-4xl font-bold mb-12 text-black">
-            What makes Habee different?
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-black">
+            Features
           </h2>
-          <div className="grid gap-16 sm:grid-cols-3 text-left">
-            <div className="space-y-4">
-              <CalendarCheck className="w-6 h-6 text-black" />
-              <h3 className="font-semibold text-lg text-black">
-                Daily habit logging
-              </h3>
-              <p className="text-sm leading-relaxed text-black">
-                Tick off your goals with ease in a clean, focused interface
-                designed for speed.
-              </p>
-            </div>
-            <div className="space-y-4">
-              <BarChart className="w-6 h-6 text-black" />
-              <h3 className="font-semibold text-lg text-black">
-                Visual streaks
-              </h3>
-              <p className="text-sm leading-relaxed text-black">
-                See your progress day by day — with intuitive calendar colour
-                indicators.
-              </p>
-            </div>
-            <div className="space-y-4">
-              <Bell className="w-6 h-6 text-black" />
-              <h3 className="font-semibold text-lg text-black">
-                Smart reminders
-              </h3>
-              <p className="text-sm leading-relaxed text-black">
-                Optional nudges that fit your schedule — no spam, just gentle
-                motivation.
-              </p>
-            </div>
-          </div>
+          <ul className="list-disc space-y-4 text-left text-lg leading-relaxed text-black">
+            <li>
+              Create, edit, and delete habits with daily or weekly schedules and
+              day-of-week selection.
+            </li>
+            <li>
+              Habit archiving/unarchiving and archived-habits management.
+            </li>
+            <li>
+              Daily reminder plus custom per-habit reminders (up to 20).
+            </li>
+            <li>
+              Support link, about section, logout, and account deletion.
+            </li>
+          </ul>
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,30 @@
 import Nav from "@/components/nav";
-import { BarChart, Bell, CalendarCheck } from "lucide-react";
+import { BarChart, Bell, CalendarCheck, Hexagon } from "lucide-react";
 
 export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">
       <Nav />
 
+      {/* Hero — What is Habee? */}
       <main className="flex-1 flex flex-col items-center text-center px-6">
         <div className="max-w-3xl w-full">
           <h1 className="mt-12 text-4xl md:text-5xl font-extrabold">
-            Build better habits.
+            What is Habee?
           </h1>
+
           <p className="mt-6 text-lg leading-relaxed text-balance">
-            Habee is a clean, distraction-free habit tracker designed to help
-            you build daily routines that last. With a minimalist UI and zero
-            ads, Habee helps you stay consistent over time — giving you a
-            satisfying visual of your long-term progress.
+            <strong>Habee</strong> (pronounced <em>ha‑bee</em>) is a clean,
+            distraction‑free habit tracker. The black and yellow branding is
+            inspired by the <strong>bee</strong>: focused, organised, and
+            relentless at getting things done. You’ll see{" "}
+            <strong>hexagons</strong> throughout the design — a nod to the
+            honeycomb: simple building blocks that, over time, create something
+            strong and beautiful. That’s the idea behind Habee — consistent,
+            lightweight actions that compound into real progress.
           </p>
+
+          {/* Primary CTAs */}
           <div className="mt-10 flex flex-col sm:flex-row justify-center gap-4">
             <a
               href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
@@ -27,33 +35,34 @@ export default function Home() {
               Support
             </a>
             <a
-              href="https://github.com/shafiul23/habee-app"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/about"
               className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold"
             >
-              View GitHub
+              About
             </a>
           </div>
         </div>
       </main>
 
+      {/* Section 2 — What it does / why it’s useful */}
       <section id="features" className="py-16 px-6 bg-[var(--accent)] mt-10">
         <div className="max-w-6xl mx-auto text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-12 text-black">
-            What makes Habee different?
+            What does Habee do?
           </h2>
+
           <div className="grid gap-16 sm:grid-cols-3 text-left">
             <div className="space-y-4">
-              <CalendarCheck className="w-6 h-6 text-black" />
+              <CalendarCheck className="w-6 h-6 text-black" aria-hidden />
               <h3 className="font-semibold text-lg text-black">
-                Daily habit logging
+                Daily and weekly habit logging
               </h3>
               <p className="text-sm leading-relaxed text-black">
-                Tick off your goals with ease in a clean, focused interface
-                designed for speed.
+                Tick off your habits in seconds with a fast, focused interface —
+                no clutter, no ads, no productivity paralysis.
               </p>
             </div>
+
             <div className="space-y-4">
               <BarChart className="w-6 h-6 text-black" />
               <h3 className="font-semibold text-lg text-black">
@@ -61,35 +70,42 @@ export default function Home() {
               </h3>
               <p className="text-sm leading-relaxed text-black">
                 See your progress day by day — with intuitive calendar colour
-                indicators.
+                indicators, and deeper break downs on the Grid screen.
               </p>
             </div>
+
             <div className="space-y-4">
-              <Bell className="w-6 h-6 text-black" />
+              <Bell className="w-6 h-6 text-black" aria-hidden />
               <h3 className="font-semibold text-lg text-black">
                 Smart reminders
               </h3>
               <p className="text-sm leading-relaxed text-black">
-                Optional nudges that fit your schedule — no spam, just gentle
-                motivation.
+                Optional nudges that fit your schedule — supportive, not spammy
+                — to keep momentum without stress.
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      <section id="donate" className="py-10 px-6 text-center">
+      {/* Section 3 — Support teaser */}
+      <section id="donate" className="py-12 px-6 text-center">
         <div className="max-w-3xl mx-auto">
           <h2 className="text-3xl font-bold mb-4">Support Habee</h2>
           <p className="text-lg text-balance">
-            Habee will always be <strong>ad-free</strong>,{" "}
-            <strong>tracking-free</strong>, and{" "}
-            <strong>focused on user wellbeing</strong>. It’s built and
-            maintained by a solo developer. Your donation helps cover hosting,
-            design, and future features like habit journaling and AI-powered
-            insights — all without selling your data.
+            Habee is built and maintained by a solo developer and will stay
+            <strong> ad‑free</strong> and <strong>tracking‑free</strong>. Your
+            support helps cover hosting, design, and future features like habit
+            journaling and AI-powered insights — all without selling your data.
           </p>
-          <div className="mt-8">
+
+          <div className="mt-8 flex flex-col sm:flex-row justify-center gap-4">
+            <a
+              href="/support"
+              className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold"
+            >
+              Learn more
+            </a>
             <a
               href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
               target="_blank"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
             </a>
             <a
               href="/about"
-              className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold"
+              className="bg-[var(--accent)] text-black px-6 py-3 rounded-full font-semibold"
             >
               About
             </a>
@@ -102,7 +102,7 @@ export default function Home() {
           <div className="mt-8 flex flex-col sm:flex-row justify-center gap-4">
             <a
               href="/support"
-              className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold"
+              className="bg-[var(--accent)] text-black px-6 py-3 rounded-full font-semibold"
             >
               Learn more
             </a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import Nav from "@/components/nav";
+import { BarChart, Bell, CalendarCheck } from "lucide-react";
 
 export default function Home() {
   return (
@@ -18,42 +18,63 @@ export default function Home() {
             satisfying visual of your long-term progress.
           </p>
           <div className="mt-10 flex flex-col sm:flex-row justify-center gap-4">
-            <Link
-              href="/support"
+            <a
+              href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
+              target="_blank"
+              rel="noopener noreferrer"
               className="bg-[var(--accent)] text-black px-6 py-3 rounded-full font-semibold"
             >
               Support
-            </Link>
-            <Link
-              href="/about"
+            </a>
+            <a
+              href="https://github.com/shafiul23/habee-app"
+              target="_blank"
+              rel="noopener noreferrer"
               className="border border-[var(--accent)] text-[var(--accent)] px-6 py-3 rounded-full font-semibold"
             >
-              About
-            </Link>
+              View GitHub
+            </a>
           </div>
         </div>
       </main>
 
       <section id="features" className="py-16 px-6 bg-[var(--accent)] mt-10">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-black">
-            Features
+        <div className="max-w-6xl mx-auto text-center">
+          <h2 className="text-3xl md:text-4xl font-bold mb-12 text-black">
+            What makes Habee different?
           </h2>
-          <ul className="list-disc space-y-4 text-left text-lg leading-relaxed text-black">
-            <li>
-              Create, edit, and delete habits with daily or weekly schedules and
-              day-of-week selection.
-            </li>
-            <li>
-              Habit archiving/unarchiving and archived-habits management.
-            </li>
-            <li>
-              Daily reminder plus custom per-habit reminders (up to 20).
-            </li>
-            <li>
-              Support link, about section, logout, and account deletion.
-            </li>
-          </ul>
+          <div className="grid gap-16 sm:grid-cols-3 text-left">
+            <div className="space-y-4">
+              <CalendarCheck className="w-6 h-6 text-black" />
+              <h3 className="font-semibold text-lg text-black">
+                Daily habit logging
+              </h3>
+              <p className="text-sm leading-relaxed text-black">
+                Tick off your goals with ease in a clean, focused interface
+                designed for speed.
+              </p>
+            </div>
+            <div className="space-y-4">
+              <BarChart className="w-6 h-6 text-black" />
+              <h3 className="font-semibold text-lg text-black">
+                Visual streaks
+              </h3>
+              <p className="text-sm leading-relaxed text-black">
+                See your progress day by day — with intuitive calendar colour
+                indicators.
+              </p>
+            </div>
+            <div className="space-y-4">
+              <Bell className="w-6 h-6 text-black" />
+              <h3 className="font-semibold text-lg text-black">
+                Smart reminders
+              </h3>
+              <p className="text-sm leading-relaxed text-black">
+                Optional nudges that fit your schedule — no spam, just gentle
+                motivation.
+              </p>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,26 +1,9 @@
-import Link from "next/link";
+import Nav from "@/components/nav";
 
 export default function Privacy() {
   return (
     <div className="flex flex-col min-h-screen">
-      <header className="bg-[var(--accent)] py-4 px-6">
-        <div className="mx-auto flex items-center justify-between">
-          <Link
-            href="/"
-            className="text-2xl font-bold text-black hover:text-white transition-colors"
-          >
-            habee
-          </Link>
-          <nav className="flex gap-6 text-sm font-medium text-black">
-            <Link href="/#donate" className="hover:text-white">
-              Support
-            </Link>
-            <Link href="/privacy" className="hover:text-white">
-              Privacy
-            </Link>
-          </nav>
-        </div>
-      </header>
+      <Nav />
 
       <main className="flex-1 px-6">
         <div className="max-w-3xl mx-auto py-12">

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,43 @@
+import Nav from "@/components/nav";
+
+export default function Support() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Nav />
+
+      <main className="flex-1 px-6">
+        <div className="max-w-3xl mx-auto py-12">
+          <h1 className="text-3xl md:text-4xl font-bold mb-6 text-center">
+            Support Habee
+          </h1>
+          <p className="text-lg leading-relaxed text-balance">
+            Habee will always be ad-free, tracking-free, and focused on helping
+            you build lasting routines. It&apos;s built and maintained by a solo
+            developer who relies on community contributions to keep the project
+            running.
+          </p>
+          <p className="mt-6 text-lg leading-relaxed text-balance">
+            Your support covers hosting costs, design work, and development of
+            new features like habit journaling and smarter reminders — all while
+            keeping your data private and never selling it to advertisers.
+          </p>
+          <div className="mt-8 text-center">
+            <a
+              href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-[var(--accent)] text-black px-6 py-3 rounded-full font-semibold inline-block"
+            >
+              Support via Stripe
+            </a>
+          </div>
+        </div>
+      </main>
+
+      <footer className="py-8 text-center text-sm mt-auto">
+        © {new Date().getFullYear()} Habee. Built by Mirza Digital Group.
+      </footer>
+    </div>
+  );
+}
+

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,4 +1,18 @@
+import { Card } from "@/components/Card";
 import Nav from "@/components/nav";
+
+import {
+  Server,
+  Database,
+  Apple,
+  ArrowRightLeft,
+  ShieldCheck,
+  Sparkles,
+  GitBranch,
+  Share2,
+  Star,
+  MessageSquare,
+} from "lucide-react";
 
 export default function Support() {
   return (
@@ -7,30 +21,192 @@ export default function Support() {
 
       <main className="flex-1 px-6">
         <div className="max-w-3xl mx-auto py-12">
-          <h1 className="text-3xl md:text-4xl font-bold mb-6 text-center">
-            Support Habee
-          </h1>
-          <p className="text-lg leading-relaxed text-balance">
-            Habee will always be ad-free, tracking-free, and focused on helping
-            you build lasting routines. It&apos;s built and maintained by a solo
-            developer who relies on community contributions to keep the project
-            running.
-          </p>
-          <p className="mt-6 text-lg leading-relaxed text-balance">
-            Your support covers hosting costs, design work, and development of
-            new features like habit journaling and smarter reminders — all while
-            keeping your data private and never selling it to advertisers.
-          </p>
-          <div className="mt-8 text-center">
-            <a
-              href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bg-[var(--accent)] text-black px-6 py-3 rounded-full font-semibold inline-block"
-            >
-              Support via Stripe
-            </a>
-          </div>
+          {/* Header */}
+          <header className="text-center">
+            <h1 className="text-3xl md:text-4xl font-bold mb-2">
+              Support Habee
+            </h1>
+            <p className="text-sm opacity-70">
+              Keep Habee <strong>ad‑free</strong>,{" "}
+              <strong>tracking‑free</strong>, and focused on your progress.
+            </p>
+          </header>
+
+          {/* Why support */}
+          <section className="mt-10">
+            <Card>
+              <h2 className="text-xl font-semibold">
+                Why your support matters
+              </h2>
+              <p className="mt-4 text-lg leading-relaxed text-balance">
+                Habee is built and maintained by a solo developer. Community
+                support helps cover the ongoing costs of running the app and
+                funds thoughtful improvements — without selling your data or
+                cluttering the experience with ads.
+              </p>
+            </Card>
+          </section>
+
+          {/* Where funds go */}
+          <section className="mt-6">
+            <Card accent>
+              <h2 className="text-xl font-semibold">Where your support goes</h2>
+              <ul className="mt-4 grid gap-3">
+                <li className="flex items-start gap-3">
+                  <Server className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Hosting & infrastructure</p>
+                    <p className="opacity-90">
+                      App servers, APIs, uptime monitoring — keeping things fast
+                      and reliable.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Database className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Database & storage</p>
+                    <p className="opacity-90">
+                      Secure, scalable storage for your habits and progress.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Apple className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">App store accounts & tooling</p>
+                    <p className="opacity-90">
+                      Developer program fees, build pipelines, testing devices.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <ShieldCheck className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Privacy & security</p>
+                    <p className="opacity-90">
+                      Best‑practice authentication, backups, and protection —
+                      without trackers.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Sparkles className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Design & polish</p>
+                    <p className="opacity-90">
+                      Crafting a clean, accessible experience that feels great
+                      to use.
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </Card>
+          </section>
+
+          {/* What support unlocks */}
+          <section className="mt-6">
+            <Card>
+              <h2 className="text-xl font-semibold">
+                What your support helps build
+              </h2>
+              <ul className="mt-4 grid gap-3">
+                <li className="flex items-start gap-3">
+                  <GitBranch className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Steady feature delivery</p>
+                    <p className="opacity-90">
+                      Faster iterations on highly requested features, without
+                      bloat.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Sparkles className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Future ideas</p>
+                    <p className="opacity-90">
+                      Journalling, dark mode, non‑binary logging, and
+                      privacy‑first insights about habit behaviour using AI.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <ArrowRightLeft
+                    className="w-5 h-5 mt-1 shrink-0"
+                    aria-hidden
+                  />
+                  <div>
+                    <p className="font-medium">Cross‑platform stability</p>
+                    <p className="opacity-90">
+                      Better build tooling, testing, and QA for smooth updates
+                      on iOS and Android.
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </Card>
+          </section>
+
+          {/* Alternative ways to support */}
+          <section className="mt-6">
+            <Card accent>
+              <h2 className="text-xl font-semibold">Other ways to support</h2>
+              <ul className="mt-4 grid gap-3">
+                <li className="flex items-start gap-3">
+                  <Star className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Leave a review</p>
+                    <p className="opacity-90">
+                      Reviews help more people discover Habee.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Share2 className="w-5 h-5 mt-1 shrink-0" aria-hidden />
+                  <div>
+                    <p className="font-medium">Share with a friend</p>
+                    <p className="opacity-90">
+                      If Habee helps you, pass it on.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <MessageSquare
+                    className="w-5 h-5 mt-1 shrink-0"
+                    aria-hidden
+                  />
+                  <div>
+                    <p className="font-medium">Send feedback</p>
+                    <p className="opacity-90">
+                      Email{" "}
+                      <a
+                        className="underline decoration-[var(--accent)] underline-offset-4"
+                        href="mailto:habee.app@gmail.com"
+                      >
+                        habee.app@gmail.com
+                      </a>{" "}
+                      with ideas or bug reports.
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </Card>
+          </section>
+
+          {/* CTA */}
+          <section className="mt-10">
+            <div className="flex justify-center">
+              <a
+                href="https://donate.stripe.com/cNi7sN97gcizangfr43cc00"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-[var(--accent)] text-black dark:text-[var(--background)] px-6 py-3 rounded-full font-semibold inline-block hover:opacity-90 transition"
+              >
+                Support via Stripe
+              </a>
+            </div>
+          </section>
         </div>
       </main>
 
@@ -40,4 +216,3 @@ export default function Support() {
     </div>
   );
 }
-

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,13 @@
+export function Card({
+  children,
+  accent = false,
+}: {
+  children: React.ReactNode;
+  accent?: boolean;
+}) {
+  const base = "rounded-2xl border shadow-sm p-6 backdrop-blur";
+  const bg = accent
+    ? "bg-[var(--foreground)]/[0.06] border-[var(--foreground)]/[0.12]"
+    : "bg-[var(--foreground)]/[0.05] border-[var(--foreground)]/[0.10]";
+  return <div className={`${base} ${bg}`}>{children}</div>;
+}

--- a/src/components/FeatureRow.tsx
+++ b/src/components/FeatureRow.tsx
@@ -1,0 +1,19 @@
+export function FeatureRow({
+  icon,
+  title,
+  desc,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-[var(--foreground)]/[0.10] bg-[var(--foreground)]/[0.05] p-4 shadow-sm">
+      <div className="mt-1 text-[var(--foreground)]">{icon}</div>
+      <div>
+        <h3 className="font-medium">{title}</h3>
+        <p className="text-base leading-relaxed opacity-90">{desc}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+export default function Nav() {
+  return (
+    <header className="bg-[var(--accent)] py-4 px-6">
+      <div className="mx-auto flex items-center justify-between">
+        <Link
+          href="/"
+          className="text-2xl font-bold text-black hover:text-white transition-colors"
+        >
+          habee
+        </Link>
+        <nav className="flex gap-6 text-sm font-medium text-black">
+          <Link href="/about" className="hover:text-white">
+            About
+          </Link>
+          <Link href="/support" className="hover:text-white">
+            Support
+          </Link>
+          <Link href="/privacy" className="hover:text-white">
+            Privacy
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace GitHub call-to-action with About link on home page
- simplify features section into bullet list describing current app capabilities
- add About page outlining app motivation
- add Support page with donation details and Stripe link
- introduce reusable navbar linking to About, Support, and Privacy across pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74fc8be588330b8e4201750cc97cf